### PR TITLE
Correctly Generate the type names

### DIFF
--- a/solve.py
+++ b/solve.py
@@ -26,6 +26,51 @@ class Type(Enum):
     ICE = 17
     ROCK = 18
 
+#
+# Function to convert the types into the form the DB expects.
+#
+def get_type_name(typ):
+    if typ == Type.NONE:
+        return 'None'
+    elif typ == Type.NORMAL:
+        return 'Normal'
+    elif typ == Type.ELECTRIC:
+        return 'Electric'
+    elif typ == Type.PSYCHIC:
+        return 'Psychic'
+    elif typ == Type.POISON:
+        return 'Poison'
+    elif typ == Type.GHOST:
+        return 'Ghost'
+    elif typ == Type.FIRE:
+        return 'Fire'
+    elif typ == Type.WATER:
+        return 'Water'
+    elif typ == Type.GROUND:
+        return 'Ground'
+    elif typ == Type.FIGHTING:
+        return 'Fighting'
+    elif typ == Type.GRASS:
+        return 'Grass'
+    elif typ == Type.FLYING:
+        return 'Flying'
+    elif typ == Type.BUG:
+        return 'Bug'
+    elif typ == Type.DRAGON:
+        return 'Dragon'
+    elif typ == Type.FAIRY:
+        return 'Fairy'
+    elif typ == Type.STEEL:
+        return 'Steel'
+    elif typ == Type.DARK:
+        return 'Dark'
+    elif typ == Type.ICE:
+        return 'Ice'
+    elif typ == Type.ROCK:
+        return 'Rock'
+    # There is a problem if we reach here.
+    return 'ERROR'
+
 # Possible clues
 class Clue(Enum):
     WRONG = 0
@@ -168,7 +213,7 @@ def get_pick():
     # Get first listed result and return as Pokemon object
     res = cur.fetchone()
     con.close()
-    
+
     pick = Pokemon(res[0], res[1], res[2], Type[res[3].upper()], Type[res[4].upper()], res[5], res[6], res[7])
     return pick
 
@@ -236,26 +281,26 @@ while(guesses < 8 and not (\
     # Update type 1 filter
     match clues[1]:
         case Clue.WRONG:
-            type1_filter.append(pick.type1)
+            type1_filter.append(get_type_name(pick.type1))
         case Clue.WRONGPOS:
-            type1_filter.append(pick.type1)
-            type2_filter = [str(type) for type in Type]
-            type2_filter.remove(str(pick.type1))
+            type1_filter.append(get_type_name(pick.type1))
+            type2_filter = [get_type_name(type) for type in Type]
+            type2_filter.remove(get_type_name(pick.type1))
         case Clue.CORRECT:
-            type1_filter = [str(type) for type in Type]
-            type1_filter.remove(str(pick.type1))
+            type1_filter = [get_type_name(type) for type in Type]
+            type1_filter.remove(get_type_name(pick.type1))
 
     # Update type 2 filter
     match clues[2]:
         case Clue.WRONG:
-            type2_filter.append(pick.type2)
+            type2_filter.append(get_type_name(pick.type2))
         case Clue.WRONGPOS:
-            type2_filter.append(pick.type2)
-            type1_filter = [str(type) for type in Type]
-            type1_filter.remove(str(pick.type2))
+            type2_filter.append(get_type_name(pick.type2))
+            type1_filter = [get_type_name(type) for type in Type]
+            type1_filter.remove(get_type_name(pick.type2))
         case Clue.CORRECT:
-            type2_filter = [str(type) for type in Type]
-            type2_filter.remove(str(pick.type2))
+            type2_filter = [get_type_name(type) for type in Type]
+            type2_filter.remove(get_type_name(pick.type2))
 
     # Update height filter
     match clues[3]:


### PR DESCRIPTION
Prior behavior had the type names at the query-level be things like 'Type.NORMAL'. Since the database stores the equivalent type as 'Normal', I added a function to convert the type into the correct text.